### PR TITLE
Modernize waitlist and add game rule pages

### DIFF
--- a/static/games.html
+++ b/static/games.html
@@ -101,7 +101,7 @@
                   <p class="card-text">
                     See who can tap the fastest in this fun and frantic game.
                   </p>
-                  <a href="#" class="btn btn-primary mt-auto" tabindex="0"
+                  <a href="tap-it.html" class="btn btn-primary mt-auto" tabindex="0"
                     >Play</a
                   >
                 </div>
@@ -120,7 +120,7 @@
                   <p class="card-text">
                     Classic number game reimagined for real‑time play.
                   </p>
-                  <a href="#" class="btn btn-primary mt-auto" tabindex="0"
+                  <a href="tambola.html" class="btn btn-primary mt-auto" tabindex="0"
                     >Play</a
                   >
                 </div>
@@ -140,7 +140,7 @@
                     Team up and test your strength in this digital tug of
                     war.
                   </p>
-                  <a href="#" class="btn btn-primary mt-auto" tabindex="0"
+                  <a href="tug-of-war.html" class="btn btn-primary mt-auto" tabindex="0"
                     >Play</a
                   >
                 </div>
@@ -159,7 +159,7 @@
                   <p class="card-text">
                     A random number generation game for poker lovers.
                   </p>
-                  <a href="#" class="btn btn-primary mt-auto" tabindex="0"
+                  <a href="poker-number.html" class="btn btn-primary mt-auto" tabindex="0"
                     >Play</a
                   >
                 </div>

--- a/static/index.html
+++ b/static/index.html
@@ -99,18 +99,18 @@
         </p>
         <!-- Waitlist form -->
         <form
-          class="d-flex justify-content-center flex-column flex-md-row gap-2 pb-3"
+          class="waitlist-form d-flex justify-content-center flex-column flex-md-row gap-2 pb-3 mx-auto"
           aria-label="Waitlist form"
         >
           <label for="email" class="visually-hidden">Email address</label>
           <input
             type="email"
             id="email"
-            class="form-control form-control-lg"
+            class="form-control form-control-lg flex-grow-1"
             placeholder="Enter your email"
             aria-label="Enter your email"
           />
-          <button type="submit" class="btn btn-primary btn-lg">
+          <button type="submit" class="btn btn-primary btn-lg w-100 w-md-auto">
             Join Waitlist
           </button>
         </form>

--- a/static/poker-number.html
+++ b/static/poker-number.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Poker Number rules page -->
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Poker Number – Game Rules & Room | Bazonga</title>
+    <meta name="description" content="Review the rules for Poker Number on Bazonga and create a room to play." />
+    <meta property="og:title" content="Poker Number – Game Rules" />
+    <meta property="og:description" content="Read the rules for Poker Number and start a room on Bazonga." />
+    <meta property="og:image" content="assets/logo_transparent.png" />
+    <meta property="og:type" content="website" />
+    <link rel="icon" type="image/png" href="assets/logo_transparent.png" />
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <header role="banner">
+      <nav class="navbar navbar-expand-lg navbar-light fixed-top shadow-sm">
+        <div class="container">
+          <a class="navbar-brand d-flex align-items-center" href="index.html">
+            <img src="assets/logo_transparent.png" alt="Bazonga logo" width="48" height="48" class="me-2" />
+            <span class="fw-bold">Bazonga</span>
+          </a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+            <ul class="navbar-nav">
+              <li class="nav-item">
+                <a class="nav-link" href="index.html">Home</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link active" aria-current="page" href="games.html">Games</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Main content -->
+    <main class="pt-5 mt-4" role="main">
+      <section class="py-5" role="region">
+        <div class="container">
+          <h1 class="fw-bold text-center mb-4">Poker Number – Rules</h1>
+          <ol class="text-start mx-auto mb-4" style="max-width: 600px;">
+            <li>Each player joins a room and awaits the draw.</li>
+            <li>Every round, the system generates a random number for each player.</li>
+            <li>The player with the highest number wins the round.</li>
+            <li>Play multiple rounds and keep track of your score.</li>
+          </ol>
+          <div class="mx-auto" style="max-width: 400px;">
+            <label for="roomName" class="form-label">Enter a room name to play</label>
+            <input type="text" id="roomName" class="form-control form-control-lg mb-3" placeholder="Room name" />
+            <button class="btn btn-primary btn-lg w-100">Enter Room</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-dark text-white py-3" role="contentinfo">
+      <div class="container text-center">
+        <small>© 2025 Bazonga. All rights reserved.</small>
+      </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/static/style.css
+++ b/static/style.css
@@ -71,16 +71,35 @@ body {
 }
 
 /* Waitlist form */
-#hero form input[type="email"] {
-  max-width: 320px;
-  border-radius: 0.3rem;
-}
-
 #hero form .btn-primary {
   background-color: var(--primary-color);
   border-color: var(--primary-color);
   padding-left: 1.5rem;
   padding-right: 1.5rem;
+}
+
+/* Modern waitlist styling */
+.waitlist-form {
+  max-width: 500px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  padding: 1rem;
+  border-radius: 1rem;
+}
+
+.waitlist-form input[type="email"],
+.waitlist-form button {
+  border-radius: 2rem;
+}
+
+.waitlist-form input[type="email"] {
+  width: 100%;
+}
+
+@media (max-width: 767.98px) {
+  .waitlist-form button {
+    width: 100%;
+  }
 }
 
 #hero .btn-outline-light {

--- a/static/tambola.html
+++ b/static/tambola.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Tambola rules page -->
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tambola – Game Rules & Room | Bazonga</title>
+    <meta name="description" content="Understand how to play Tambola on Bazonga and create a private room." />
+    <meta property="og:title" content="Tambola – Game Rules" />
+    <meta property="og:description" content="Read the rules for Tambola and start a room on Bazonga." />
+    <meta property="og:image" content="assets/logo_transparent.png" />
+    <meta property="og:type" content="website" />
+    <link rel="icon" type="image/png" href="assets/logo_transparent.png" />
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <header role="banner">
+      <nav class="navbar navbar-expand-lg navbar-light fixed-top shadow-sm">
+        <div class="container">
+          <a class="navbar-brand d-flex align-items-center" href="index.html">
+            <img src="assets/logo_transparent.png" alt="Bazonga logo" width="48" height="48" class="me-2" />
+            <span class="fw-bold">Bazonga</span>
+          </a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+            <ul class="navbar-nav">
+              <li class="nav-item">
+                <a class="nav-link" href="index.html">Home</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link active" aria-current="page" href="games.html">Games</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Main content -->
+    <main class="pt-5 mt-4" role="main">
+      <section class="py-5" role="region">
+        <div class="container">
+          <h1 class="fw-bold text-center mb-4">Tambola – Rules</h1>
+          <ol class="text-start mx-auto mb-4" style="max-width: 600px;">
+            <li>Each player receives a ticket with random numbers.</li>
+            <li>Numbers are called out one by one.</li>
+            <li>Mark the numbers on your ticket as they are called.</li>
+            <li>First player to complete a pattern or full house wins.</li>
+          </ol>
+          <div class="mx-auto" style="max-width: 400px;">
+            <label for="roomName" class="form-label">Enter a room name to play</label>
+            <input type="text" id="roomName" class="form-control form-control-lg mb-3" placeholder="Room name" />
+            <button class="btn btn-primary btn-lg w-100">Enter Room</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-dark text-white py-3" role="contentinfo">
+      <div class="container text-center">
+        <small>© 2025 Bazonga. All rights reserved.</small>
+      </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/static/tap-it.html
+++ b/static/tap-it.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Tap It rules page -->
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tap It – Game Rules & Room | Bazonga</title>
+    <meta name="description" content="Learn how to play Tap It on Bazonga and create a room to challenge friends." />
+    <meta property="og:title" content="Tap It – Game Rules" />
+    <meta property="og:description" content="Read the rules for Tap It and start a room on Bazonga." />
+    <meta property="og:image" content="assets/logo_transparent.png" />
+    <meta property="og:type" content="website" />
+    <link rel="icon" type="image/png" href="assets/logo_transparent.png" />
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <header role="banner">
+      <nav class="navbar navbar-expand-lg navbar-light fixed-top shadow-sm">
+        <div class="container">
+          <a class="navbar-brand d-flex align-items-center" href="index.html">
+            <img src="assets/logo_transparent.png" alt="Bazonga logo" width="48" height="48" class="me-2" />
+            <span class="fw-bold">Bazonga</span>
+          </a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+            <ul class="navbar-nav">
+              <li class="nav-item">
+                <a class="nav-link" href="index.html">Home</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link active" aria-current="page" href="games.html">Games</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Main content -->
+    <main class="pt-5 mt-4" role="main">
+      <section class="py-5" role="region">
+        <div class="container">
+          <h1 class="fw-bold text-center mb-4">Tap It – Rules</h1>
+          <ol class="text-start mx-auto mb-4" style="max-width: 600px;">
+            <li>Split players into two teams.</li>
+            <li>Everyone taps their side of the screen as fast as possible.</li>
+            <li>The team with the most taps when time runs out wins.</li>
+          </ol>
+          <div class="mx-auto" style="max-width: 400px;">
+            <label for="roomName" class="form-label">Enter a room name to play</label>
+            <input type="text" id="roomName" class="form-control form-control-lg mb-3" placeholder="Room name" />
+            <button class="btn btn-primary btn-lg w-100">Enter Room</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-dark text-white py-3" role="contentinfo">
+      <div class="container text-center">
+        <small>© 2025 Bazonga. All rights reserved.</small>
+      </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/static/tug-of-war.html
+++ b/static/tug-of-war.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Tug of War rules page -->
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tug of War – Game Rules & Room | Bazonga</title>
+    <meta name="description" content="Learn the Tug of War rules on Bazonga and create a room for your team." />
+    <meta property="og:title" content="Tug of War – Game Rules" />
+    <meta property="og:description" content="Read the rules for Tug of War and start a room on Bazonga." />
+    <meta property="og:image" content="assets/logo_transparent.png" />
+    <meta property="og:type" content="website" />
+    <link rel="icon" type="image/png" href="assets/logo_transparent.png" />
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Navigation -->
+    <header role="banner">
+      <nav class="navbar navbar-expand-lg navbar-light fixed-top shadow-sm">
+        <div class="container">
+          <a class="navbar-brand d-flex align-items-center" href="index.html">
+            <img src="assets/logo_transparent.png" alt="Bazonga logo" width="48" height="48" class="me-2" />
+            <span class="fw-bold">Bazonga</span>
+          </a>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+            <ul class="navbar-nav">
+              <li class="nav-item">
+                <a class="nav-link" href="index.html">Home</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link active" aria-current="page" href="games.html">Games</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Main content -->
+    <main class="pt-5 mt-4" role="main">
+      <section class="py-5" role="region">
+        <div class="container">
+          <h1 class="fw-bold text-center mb-4">Tug of War – Rules</h1>
+          <ol class="text-start mx-auto mb-4" style="max-width: 600px;">
+            <li>Divide players evenly into two teams.</li>
+            <li>Each team taps to pull the rope toward their side.</li>
+            <li>The team that pulls the flag past the center line wins.</li>
+          </ol>
+          <div class="mx-auto" style="max-width: 400px;">
+            <label for="roomName" class="form-label">Enter a room name to play</label>
+            <input type="text" id="roomName" class="form-control form-control-lg mb-3" placeholder="Room name" />
+            <button class="btn btn-primary btn-lg w-100">Enter Room</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="bg-dark text-white py-3" role="contentinfo">
+      <div class="container text-center">
+        <small>© 2025 Bazonga. All rights reserved.</small>
+      </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://unpkg.com/scrollreveal"></script>
+    <script src="script.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Revamp waitlist section with responsive, modern styling and fix mobile width issue
- Add dedicated SEO-friendly rule pages for Tap It, Tambola, Tug of War, and Poker Number
- Link each game card to its rule page for room creation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7319f4c648323889853db0770d81b